### PR TITLE
chore: update codeowners to E4D to avoid PR assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,4 @@
 
 #ECCN:Open Source
 #GUSINFO:Einstein for Developers,Einstein for Developers
-*        @forcedotcom/tooling-team
+*        @forcedotcom/einstein-for-developers


### PR DESCRIPTION
### What does this PR do?
Change CodeOwner file to point at e4d instead of tooling team to limit auto assigned on PRs. 

### What issues does this PR fix or reference?

@W-16326254@

### Functionality Before

Most of DX could randomly get assigned PRs

### Functionality After

Limited to E4D 

