### PR TITLE
feat: manage experiment state with global memento

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -13,7 +13,6 @@ export enum ExperimentType {
 }
 
 export interface Experiment {
-  id: string;
   name: string;
   type: ExperimentType;
   distributionPercent: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,4 @@
  **/
 
 export * from './api';
-export * from './assignment';
 export * from './experimentService';

--- a/src/internals/assignment.ts
+++ b/src/internals/assignment.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  **/
 
-import { Experiment } from './api';
+import { Experiment } from '../api';
 
 export function randomAssignment(experiment: Experiment): boolean {
   const rand = Math.random() * 100;

--- a/src/internals/experimentState.ts
+++ b/src/internals/experimentState.ts
@@ -7,7 +7,7 @@
 
 import * as vscode from 'vscode';
 import { Experiment, ExperimentType } from '../api';
-import { randomAssignment } from '../assignment';
+import { randomAssignment } from './assignment';
 
 export type ExperimentState = {
   [key: string]: boolean;

--- a/src/internals/experimentState.ts
+++ b/src/internals/experimentState.ts
@@ -13,7 +13,7 @@ export type ExperimentState = {
   [key: string]: boolean;
 };
 
-export const EXPERIMENT_STATE_KEY = 'vscode.ab.experiments';
+export const EXPERIMENT_STATE_KEY = 'vscode.salesforcedx.ab.experiments';
 
 export class ExperimentStateManager {
   private context: vscode.ExtensionContext;

--- a/src/internals/experimentState.ts
+++ b/src/internals/experimentState.ts
@@ -24,7 +24,7 @@ export class ExperimentStateManager {
     this.stateCache = {};
   }
 
-  async assignExperiements(experiments: Experiment[]): Promise<void> {
+  async assignExperiments(experiments: Experiment[]): Promise<void> {
     this.stateCache = this.context.globalState.get<ExperimentState>(EXPERIMENT_STATE_KEY) || {};
 
     // assign all unassigned stateful experiments

--- a/src/internals/experimentState.ts
+++ b/src/internals/experimentState.ts
@@ -43,12 +43,12 @@ export class ExperimentStateManager {
   }
 
   getExperimentState(experiment: Experiment): boolean {
+    if (this.isExpired(experiment.expirationDate)) {
+      return false;
+    }
     // check if the experiment has been assigned
     if (this.stateCache[experiment.name] !== undefined) {
       return this.stateCache[experiment.name];
-    }
-    if (this.isExpired(experiment.expirationDate)) {
-      return false;
     }
     return randomAssignment(experiment);
   }

--- a/src/internals/experimentState.ts
+++ b/src/internals/experimentState.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ **/
+
+import * as vscode from 'vscode';
+import { Experiment, ExperimentType } from '../api';
+import { randomAssignment } from '../assignment';
+
+export type ExperimentState = {
+  [key: string]: boolean;
+};
+
+export const EXPERIMENT_STATE_KEY = 'vscode.ab.experiments';
+
+export class ExperimentStateManager {
+  private context: vscode.ExtensionContext;
+
+  constructor(context: vscode.ExtensionContext) {
+    this.context = context;
+  }
+
+  async assignExperiements(experiments: Experiment[]): Promise<void> {
+    const state: ExperimentState = this.context.globalState.get<ExperimentState>(EXPERIMENT_STATE_KEY) || {};
+
+    // assign all unassigned stateful experiments
+    experiments
+      .filter((experiment) => experiment.type === ExperimentType.Stateful)
+      .forEach((experiment) => {
+        if (state[experiment.name] === undefined) {
+          state[experiment.name] = randomAssignment(experiment);
+        }
+      });
+
+    await this.context.globalState.update(EXPERIMENT_STATE_KEY, state);
+  }
+
+  getExperimentState(experiment: Experiment): boolean {
+    // check if the experiment has been assigned
+    const state: ExperimentState = this.context.globalState.get<ExperimentState>(EXPERIMENT_STATE_KEY) || {};
+    if (state[experiment.name] !== undefined) {
+      return state[experiment.name];
+    }
+
+    return randomAssignment(experiment);
+  }
+}

--- a/test/unit/assignment.test.ts
+++ b/test/unit/assignment.test.ts
@@ -11,7 +11,6 @@ describe('randomAssignment', () => {
   it('should return true if random number is less than distribution percent', () => {
     jest.spyOn(Math, 'random').mockReturnValue(0.25);
     const experiment = {
-      id: '1',
       name: 'Experiment1',
       type: ExperimentType.Transactional,
       distributionPercent: 50
@@ -25,7 +24,6 @@ describe('randomAssignment', () => {
   it('should return false if random number is greater than distribution percent', () => {
     jest.spyOn(Math, 'random').mockReturnValue(0.75);
     const experiment = {
-      id: '1',
       name: 'Experiment1',
       type: ExperimentType.Transactional,
       distributionPercent: 50

--- a/test/unit/experimentService.test.ts
+++ b/test/unit/experimentService.test.ts
@@ -12,13 +12,11 @@ describe('ExperimentService', () => {
   it('should register and return experiments', () => {
     const experiments = [
       {
-        id: '1',
         name: 'Experiment1',
         type: ExperimentType.Stateful,
         distributionPercent: 50
       },
       {
-        id: '2',
         name: 'Experiment2',
         type: ExperimentType.Transactional,
         distributionPercent: 50

--- a/test/unit/internals/assignment.test.ts
+++ b/test/unit/internals/assignment.test.ts
@@ -5,7 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  **/
 
-import { ExperimentType, randomAssignment } from '../../src';
+import { ExperimentType } from '../../../src';
+import { randomAssignment } from '../../../src/internals/assignment';
 
 describe('randomAssignment', () => {
   it('should return true if random number is less than distribution percent', () => {

--- a/test/unit/internals/experimentState.test.ts
+++ b/test/unit/internals/experimentState.test.ts
@@ -6,11 +6,11 @@
  **/
 
 import * as vscode from 'vscode';
-import * as Assignment from '../../../src/assignment';
+import * as Assignment from '../../../src/internals/assignment';
 import { ExperimentType } from '../../../src';
 import { EXPERIMENT_STATE_KEY, ExperimentStateManager } from '../../../src/internals/experimentState';
 
-jest.mock('../../../src/assignment');
+jest.mock('../../../src/internals/assignment');
 
 const context = {
   globalState: {

--- a/test/unit/internals/experimentState.test.ts
+++ b/test/unit/internals/experimentState.test.ts
@@ -66,23 +66,47 @@ describe('ExperimentStateManager', () => {
     expect(Assignmnent.randomAssignment).not.toHaveBeenCalled();
   });
 
-  it('should get stateful experiment state from memento', () => {
-    context.globalState.get.mockReturnValue({
-      Experiment1: true
-    });
+  it('should always assign expired experiments to false', async () => {
+    context.globalState.get.mockReturnValue({});
+    jest.spyOn(Assignmnent, 'randomAssignment').mockReturnValue(true);
 
+    const experiments = [
+      {
+        name: 'Experiment1',
+        type: ExperimentType.Stateful,
+        distributionPercent: 50,
+        expirationDate: '2021-01-01'
+      },
+      {
+        name: 'Experiment2',
+        type: ExperimentType.Stateful,
+        distributionPercent: 50,
+        expirationDate: '2099-01-01'
+      }
+    ];
+    const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
+    await experimentStateManager.assignExperiements(experiments);
+
+    expect(context.globalState.update).toHaveBeenCalledWith(EXPERIMENT_STATE_KEY, {
+      Experiment1: false,
+      Experiment2: true
+    });
+  });
+
+  it('should get stateful experiment state from memento', () => {
     const experiment = {
       name: 'Experiment1',
       type: ExperimentType.Stateful,
       distributionPercent: 50
     };
     const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
+    (experimentStateManager as any).stateCache = { Experiment1: true };
     const result = experimentStateManager.getExperimentState(experiment);
+
     expect(result).toBe(true);
   });
 
   it('should get random transactional experiment state', () => {
-    context.globalState.get.mockReturnValue({});
     jest.spyOn(Assignmnent, 'randomAssignment').mockReturnValue(true);
 
     const experiment = {
@@ -95,5 +119,18 @@ describe('ExperimentStateManager', () => {
 
     expect(Assignmnent.randomAssignment).toHaveBeenCalledWith(experiment);
     expect(result).toBe(true);
+  });
+
+  it('should always return false for expired experiments', () => {
+    const experiment = {
+      name: 'Experiment1',
+      type: ExperimentType.Transactional,
+      distributionPercent: 50,
+      expirationDate: '2021-01-01'
+    };
+    const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
+    const result = experimentStateManager.getExperimentState(experiment);
+
+    expect(result).toBe(false);
   });
 });

--- a/test/unit/internals/experimentState.test.ts
+++ b/test/unit/internals/experimentState.test.ts
@@ -6,7 +6,7 @@
  **/
 
 import * as vscode from 'vscode';
-import * as Assignmnent from '../../../src/assignment';
+import * as Assignment from '../../../src/assignment';
 import { ExperimentType } from '../../../src';
 import { EXPERIMENT_STATE_KEY, ExperimentStateManager } from '../../../src/internals/experimentState';
 
@@ -22,7 +22,7 @@ const context = {
 describe('ExperimentStateManager', () => {
   it('should assign stateful and not transactional experiments', async () => {
     context.globalState.get.mockReturnValue({});
-    jest.spyOn(Assignmnent, 'randomAssignment').mockReturnValue(true);
+    jest.spyOn(Assignment, 'randomAssignment').mockReturnValue(true);
 
     const experiments = [
       {
@@ -48,7 +48,7 @@ describe('ExperimentStateManager', () => {
     context.globalState.get.mockReturnValue({
       Experiment1: true
     });
-    jest.spyOn(Assignmnent, 'randomAssignment');
+    jest.spyOn(Assignment, 'randomAssignment');
 
     const experiments = [
       {
@@ -63,12 +63,12 @@ describe('ExperimentStateManager', () => {
     expect(context.globalState.update).toHaveBeenCalledWith(EXPERIMENT_STATE_KEY, {
       Experiment1: true
     });
-    expect(Assignmnent.randomAssignment).not.toHaveBeenCalled();
+    expect(Assignment.randomAssignment).not.toHaveBeenCalled();
   });
 
   it('should always assign expired experiments to false', async () => {
     context.globalState.get.mockReturnValue({});
-    jest.spyOn(Assignmnent, 'randomAssignment').mockReturnValue(true);
+    jest.spyOn(Assignment, 'randomAssignment').mockReturnValue(true);
 
     const experiments = [
       {
@@ -107,7 +107,7 @@ describe('ExperimentStateManager', () => {
   });
 
   it('should get random transactional experiment state', () => {
-    jest.spyOn(Assignmnent, 'randomAssignment').mockReturnValue(true);
+    jest.spyOn(Assignment, 'randomAssignment').mockReturnValue(true);
 
     const experiment = {
       name: 'Experiment1',
@@ -117,7 +117,7 @@ describe('ExperimentStateManager', () => {
     const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
     const result = experimentStateManager.getExperimentState(experiment);
 
-    expect(Assignmnent.randomAssignment).toHaveBeenCalledWith(experiment);
+    expect(Assignment.randomAssignment).toHaveBeenCalledWith(experiment);
     expect(result).toBe(true);
   });
 

--- a/test/unit/internals/experimentState.test.ts
+++ b/test/unit/internals/experimentState.test.ts
@@ -37,7 +37,7 @@ describe('ExperimentStateManager', () => {
       }
     ];
     const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
-    await experimentStateManager.assignExperiements(experiments);
+    await experimentStateManager.assignExperiments(experiments);
 
     expect(context.globalState.update).toHaveBeenCalledWith(EXPERIMENT_STATE_KEY, {
       Experiment1: true
@@ -58,7 +58,7 @@ describe('ExperimentStateManager', () => {
       }
     ];
     const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
-    await experimentStateManager.assignExperiements(experiments);
+    await experimentStateManager.assignExperiments(experiments);
 
     expect(context.globalState.update).toHaveBeenCalledWith(EXPERIMENT_STATE_KEY, {
       Experiment1: true
@@ -85,7 +85,7 @@ describe('ExperimentStateManager', () => {
       }
     ];
     const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
-    await experimentStateManager.assignExperiements(experiments);
+    await experimentStateManager.assignExperiments(experiments);
 
     expect(context.globalState.update).toHaveBeenCalledWith(EXPERIMENT_STATE_KEY, {
       Experiment1: false,

--- a/test/unit/internals/experimentState.test.ts
+++ b/test/unit/internals/experimentState.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ **/
+
+import * as vscode from 'vscode';
+import * as Assignmnent from '../../../src/assignment';
+import { ExperimentType } from '../../../src';
+import { EXPERIMENT_STATE_KEY, ExperimentStateManager } from '../../../src/internals/experimentState';
+
+jest.mock('../../../src/assignment');
+
+const context = {
+  globalState: {
+    get: jest.fn(),
+    update: jest.fn()
+  }
+};
+
+describe('ExperimentStateManager', () => {
+  it('should assign stateful and not transactional experiments', async () => {
+    context.globalState.get.mockReturnValue({});
+    jest.spyOn(Assignmnent, 'randomAssignment').mockReturnValue(true);
+
+    const experiments = [
+      {
+        name: 'Experiment1',
+        type: ExperimentType.Stateful,
+        distributionPercent: 50
+      },
+      {
+        name: 'Experiment2',
+        type: ExperimentType.Transactional,
+        distributionPercent: 50
+      }
+    ];
+    const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
+    await experimentStateManager.assignExperiements(experiments);
+
+    expect(context.globalState.update).toHaveBeenCalledWith(EXPERIMENT_STATE_KEY, {
+      Experiment1: true
+    });
+  });
+
+  it('should not reassign experiments already assigned', async () => {
+    context.globalState.get.mockReturnValue({
+      Experiment1: true
+    });
+    jest.spyOn(Assignmnent, 'randomAssignment');
+
+    const experiments = [
+      {
+        name: 'Experiment1',
+        type: ExperimentType.Stateful,
+        distributionPercent: 50
+      }
+    ];
+    const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
+    await experimentStateManager.assignExperiements(experiments);
+
+    expect(context.globalState.update).toHaveBeenCalledWith(EXPERIMENT_STATE_KEY, {
+      Experiment1: true
+    });
+    expect(Assignmnent.randomAssignment).not.toHaveBeenCalled();
+  });
+
+  it('should get stateful experiment state from memento', () => {
+    context.globalState.get.mockReturnValue({
+      Experiment1: true
+    });
+
+    const experiment = {
+      name: 'Experiment1',
+      type: ExperimentType.Stateful,
+      distributionPercent: 50
+    };
+    const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
+    const result = experimentStateManager.getExperimentState(experiment);
+    expect(result).toBe(true);
+  });
+
+  it('should get random transactional experiment state', () => {
+    context.globalState.get.mockReturnValue({});
+    jest.spyOn(Assignmnent, 'randomAssignment').mockReturnValue(true);
+
+    const experiment = {
+      name: 'Experiment1',
+      type: ExperimentType.Transactional,
+      distributionPercent: 50
+    };
+    const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
+    const result = experimentStateManager.getExperimentState(experiment);
+
+    expect(Assignmnent.randomAssignment).toHaveBeenCalledWith(experiment);
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?

This PR:
- assigns stateful experiments a random value and persists and loads the value using the `globalState` memento 
- assigns transactional experiments a random value

### What issues does this PR fix or reference?

@W-16328954@

