### PR TITLE
feat: add method for getting populated experiments

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -7,4 +7,6 @@ on:
 jobs:
   automerge:
     uses: salesforcecli/github-workflows/.github/workflows/automerge.yml@main
+    with:
+      GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
     secrets: inherit

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,9 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.4.2",
         "wireit": "^0.14.5"
+      },
+      "peerDependencies": {
+        "@types/vscode": "^1.76.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "typescript": "^5.4.2",
     "wireit": "^0.14.5"
   },
+  "peerDependencies": {
+    "@types/vscode": "^1.76.0"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  **/
 
-import {ExtensionContext} from 'vscode';
+import { ExtensionContext } from 'vscode';
 
 export enum ExperimentType {
   Transactional = 'transactional',
@@ -14,7 +14,6 @@ export enum ExperimentType {
 
 export enum ExperimentStatus {
   Active = 'active',
-  Disabled = 'disabled',
   Expired = 'expired'
 }
 
@@ -27,12 +26,13 @@ export interface ExperimentDefinition {
 
 export interface Experiment extends ExperimentDefinition {
   status: ExperimentStatus;
+  state: boolean;
 }
 
 export interface IExperimentService {
   registerExperiments(context: ExtensionContext, experiments: ExperimentDefinition[]): Promise<void>;
   getExperiments(): Experiment[];
-  getExperimentsState(): ExperimentState
+  getExperimentsState(): ExperimentState;
   getExperimentState(experiment: ExperimentDefinition): boolean;
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  **/
 
-import * as vscode from 'vscode';
+import {ExtensionContext} from 'vscode';
 
 export enum ExperimentType {
   Transactional = 'transactional',
@@ -14,6 +14,7 @@ export enum ExperimentType {
 
 export enum ExperimentStatus {
   Active = 'active',
+  Disabled = 'disabled',
   Expired = 'expired'
 }
 
@@ -29,6 +30,12 @@ export interface Experiment extends ExperimentDefinition {
 }
 
 export interface IExperimentService {
-  registerExperiments(context: vscode.ExtensionContext, experiments: ExperimentDefinition[]): void;
+  registerExperiments(context: ExtensionContext, experiments: ExperimentDefinition[]): Promise<void>;
   getExperiments(): Experiment[];
+  getExperimentsState(): ExperimentState
+  getExperimentState(experiment: ExperimentDefinition): boolean;
 }
+
+export type ExperimentState = {
+  [key: string]: boolean;
+};

--- a/src/experimentService.ts
+++ b/src/experimentService.ts
@@ -11,8 +11,6 @@ import { ExperimentStateManager } from './internals/experimentState';
 
 export const REGISTER_FIRST_ERROR = 'You must first register experiments';
 class ExperimentService implements IExperimentService {
-  // private experiments: ExperimentDefinition[] = [];
-
   private static instance: ExperimentService;
 
   public static getInstance(): ExperimentService {

--- a/src/experimentService.ts
+++ b/src/experimentService.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import { ExperimentDefinition, Experiment, IExperimentService, ExperimentState } from './api';
 import { ExperimentStateManager } from './internals/experimentState';
 
+export const REGISTER_FIRST_ERROR = 'You must first register experiments';
 class ExperimentService implements IExperimentService {
   // private experiments: ExperimentDefinition[] = [];
 
@@ -27,27 +28,34 @@ class ExperimentService implements IExperimentService {
   private constructor() {}
 
   async registerExperiments(context: vscode.ExtensionContext, experiments: ExperimentDefinition[]): Promise<void> {
-    this.stateManager =  new ExperimentStateManager(context);
+    this.stateManager = new ExperimentStateManager(context);
     await this.stateManager.assignExperiments(experiments);
   }
 
   // Used to get the populated experiments after registration.
   getExperiments(): Experiment[] {
-    const result =  this.stateManager?.getExperiments();
-    return result || [];
+    if (!this.stateManager) {
+      throw new Error(REGISTER_FIRST_ERROR);
+    }
+    return this.stateManager.getExperiments();
   }
 
-  // Used to get the state of all experiments (just booleans by name).  
-  // Will be useful for updating telemetry calls. 
+  // Used to get the state of all experiments (just booleans by name).
+  // Will be useful for updating telemetry calls.
   getExperimentsState(): ExperimentState {
-    const result =  this.stateManager?.getExperimentsState();
-    return result || {};
+    if (!this.stateManager) {
+      throw new Error(REGISTER_FIRST_ERROR);
+    }
+    return this.stateManager.getExperimentsState();
   }
 
-  // Get the current state of a single experiment. 
+  // Get the current state of a single experiment.
   getExperimentState(experiment: ExperimentDefinition): boolean {
-    const result = this.stateManager?.getExperimentState(experiment);
-    return result || false;
+    if (!this.stateManager) {
+      throw new Error(REGISTER_FIRST_ERROR);
+    }
+    const result = this.stateManager.getExperimentState(experiment);
+    return result;
   }
 }
 

--- a/src/internals/experimentState.ts
+++ b/src/internals/experimentState.ts
@@ -58,11 +58,11 @@ export class ExperimentStateManager {
     return randomAssignment(experiment);
   }
 
-  getExperimentsState(): typeof this.stateCache {
+  getExperimentsState(): ExperimentState {
     return this.stateCache;
   }
 
-  getExperiments(): typeof this.experiments {
+  getExperiments(): Experiment[] {
     return this.experiments;
   }
 }

--- a/test/unit/internals/experimentState.test.ts
+++ b/test/unit/internals/experimentState.test.ts
@@ -7,7 +7,7 @@
 
 import * as vscode from 'vscode';
 import * as Utils from '../../../src/internals/utils';
-import { ExperimentType } from '../../../src';
+import { Experiment, ExperimentStatus, ExperimentType } from '../../../src';
 import { EXPERIMENT_STATE_KEY, ExperimentStateManager } from '../../../src/internals/experimentState';
 
 const context = {
@@ -19,7 +19,7 @@ const context = {
 
 describe('ExperimentStateManager', () => {
   it('should assign stateful and not transactional experiments', async () => {
-    context.globalState.get.mockReturnValue({});
+    context.globalState.get.mockReturnValue(undefined);
     jest.spyOn(Utils, 'randomAssignment').mockReturnValue(true);
 
     const experiments = [
@@ -130,5 +130,49 @@ describe('ExperimentStateManager', () => {
     const result = experimentStateManager.getExperimentState(experiment);
 
     expect(result).toBe(false);
+  });
+
+  it('Should default to empty object for state of all experiments.', () => {
+    const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
+    const result = experimentStateManager.getExperimentsState();
+
+    expect(result).toEqual({});
+  });
+
+  it('Should be able to get the state of all experiments.', () => {
+    const expected = {
+      Experiment1: true,
+      Experiment2: false
+    };
+
+    const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
+    (experimentStateManager as any).stateCache = expected;
+    const result = experimentStateManager.getExperimentsState();
+
+    expect(result).toEqual(expected);
+  });
+
+  it('Should be able to get experiments.', () => {
+    const fakeExperiments: Experiment[] = [
+      {
+        name: 'Experiment1',
+        type: ExperimentType.Transactional,
+        distributionPercent: 50,
+        status: ExperimentStatus.Active,
+        state: true
+      }
+    ];
+    const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
+    (experimentStateManager as any).experiments = fakeExperiments;
+    const result = experimentStateManager.getExperiments();
+
+    expect(result).toEqual(fakeExperiments);
+  });
+
+  it('Should default experiments to empty list.', () => {
+    const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
+    const result = experimentStateManager.getExperiments();
+
+    expect(result).toEqual([]);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,12 @@
     "module": "Node16",
     "target": "ES2022",
     "lib": ["ES2023"],
-    "outDir": "out",
+    "outDir": "lib",
     "sourceMap": true,
     "declaration": true,
     "alwaysStrict": true,
     "noUnusedLocals": true,
     "strict": true
-  }
+  }, 
+  "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
### What does this PR do?
I wired up the experiments service with E4D just to verify things are working as expected.  Led me down a refactoring/extending path.  

Added method for: 
- getting populated experiments with status 
- getting single experiment status
- getting list of key/value (ExperimentState) values 

### What issues does this PR fix or reference?
@W-16328933@
@W-16328936@

### How to link with E4D
in this repo run 
1. npm install
2. npm compile
3. npm link
4. rm -rf node_modules
5. npm install --omit=dev

In the extension repo
1. npm link @salesforce/salesforcedx-vscode-experiments

Example usage
```


 const experiments: ExperimentDefinition[] = [{
    name: 'RAG-Test',
    type: ExperimentType.Stateful,
    distributionPercent: 50,
    expirationDate: '2024-12-31T23:59:59Z'
  },
{
  name: 'RAG-Test1',
  type: ExperimentType.Stateful,
  distributionPercent: 99,
  expirationDate: '2024-01-31T23:59:59Z'
},
{
  name: 'RAG-Test2',
  type: ExperimentType.Stateful,
  distributionPercent: 99,
  expirationDate: '2024-12-31T23:59:59Z'
}];

  const experimentService = getExperimentService();
  await experimentService.registerExperiments(context, experiments);
  const assignedExperiments = experimentService.getExperiments();
  const experimentsState = experimentService.getExperimentsState();
  const isOn = experimentService.getExperimentState(experiments[0]);
  console.log('***** Experiment ***** ', assignedExperiments);
  console.log('***** Experiment ***** ', isOn, experimentsState);
```



