### PR TITLE
chore: update validate to format & lint, pull in npm publish for npm

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -1,0 +1,134 @@
+on:
+    workflow_call:
+      secrets:
+        NPM_TOKEN:
+          description: npm token
+        AWS_ACCESS_KEY_ID:
+          description: AWS access key id. Only required if sign = true
+        AWS_SECRET_ACCESS_KEY:
+          description: AWS secret access key. Only required if sign = true
+  
+      inputs:
+        tag:
+          required: false
+          description: tag used to publish to npm
+          default: latest
+          type: string
+        sign:
+          required: false
+          description: signs the package using sf-release if set to true
+          default: false
+          type: boolean
+        dryrun:
+          required: false
+          description: if true, the job will run but will not publish to npm or push to git
+          default: false
+          type: boolean
+        prerelease:
+          required: false
+          description: if true, it will use the version <version>-<branch>.0
+          type: boolean
+          default: false
+        nodeVersion:
+          description: version of node to use.  It's better to specify latest, lts/* or lts/-1 than to hardode numbers
+          type: string
+          default: lts/*
+          required: false
+        ctc:
+          description: |
+            Use CTC.  Requires environment to contain
+            SF_CHANGE_CASE_SFDX_AUTH_URL, SF_CHANGE_CASE_TEMPLATE_ID, SF_CHANGE_CASE_CONFIGURATION_ITEM.
+            Also requires a static ip runner (you can't use ubuntu-latest)
+          type: boolean
+          required: false
+        runsOn:
+          description: the runner.  Only needed if you need a non-public runner (ex, for git checkout from IP restricted private repo)
+          default: ubuntu-latest
+          required: false
+          type: string
+        githubTag:
+          description: the github release tag that you want to publish as an npm package
+          required: true
+          type: string
+  jobs:
+    check-publish:
+      outputs:
+        published: ${{ steps.is-published.outputs.published }}
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+          with:
+            ref: ${{ inputs.githubTag }}
+        - uses: actions/setup-node@v4
+          with:
+            node-version: ${{ inputs.nodeVersion }}
+        - name: Is published
+          id: is-published
+          run: |
+            RESPONSE=$(npm view .@${{ inputs.githubTag }} version --json --silent || echo "Not published")
+  
+            if [ "$RESPONSE" = "\"${{ inputs.githubTag }}\"" ]; then
+              echo "published=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "published=false" >> "$GITHUB_OUTPUT"
+            fi
+          env:
+            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        - run: echo "published said ${{ steps.is-published.outputs.published }}"
+        - name: Fail if published
+          if: steps.is-published.outputs.published == 'true'
+          uses: actions/github-script@v7
+          with:
+            script: core.setFailed("The version '${{ inputs.githubTag }}' has already been published to npm")
+  
+    ctc-open:
+      needs: [check-publish]
+      if: inputs.ctc && needs.check-publish.outputs.published == 'false' && inputs.tag == 'latest'
+      uses: salesforcecli/github-workflows/.github/workflows/ctcOpen.yml@main
+      secrets: inherit
+  
+    npm-publish:
+      needs: [check-publish, ctc-open]
+      if: ${{ always() && needs.check-publish.outputs.published == 'false' && (!inputs.ctc || (inputs.ctc && needs.ctc-open.outputs.changeCaseId)) }}
+      runs-on: ${{ inputs.runsOn }}
+      steps:
+        - uses: actions/checkout@v4
+          with:
+            ref: ${{ inputs.githubTag }}
+        - uses: actions/setup-node@v4
+          with:
+            node-version-file: '.nvmrc'
+            cache: npm
+        - run: npm ci
+        - run: npm run build
+        - run: npm install -g @salesforce/plugin-release-management
+        - name: NPM Release
+          run: |
+            sf-release npm:package:release \
+              --githubtag ${{ inputs.githubTag}} \
+              --npmtag ${{ inputs.tag }} \
+              --no-install \
+              ${{ inputs.dryrun && '--dryrun' || '' }} \
+              ${{ inputs.prerelease && format('--prerelease {0}', github.ref_name) || '' }} \
+              ${{ inputs.sign && '--sign' || '' }}
+          env:
+            NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+            AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+            AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+  
+    ctcCloseSuccess:
+      needs: [ctc-open, npm-publish]
+      if: needs.ctc-open.result == 'success' && needs.npm-publish.result == 'success' && needs.ctc-open.outputs.changeCaseId
+      uses: salesforcecli/github-workflows/.github/workflows/ctcClose.yml@main
+      secrets: inherit
+      with:
+        changeCaseId: ${{needs.ctc-open.outputs.changeCaseId}}
+  
+    ctcCloseFail:
+      needs: [ctc-open, npm-publish]
+      if: always() && inputs.ctc && needs.ctc-open.outputs.changeCaseId && (needs.ctc-open.result != 'success' || needs.npm-publish.result != 'success')
+      uses: salesforcecli/github-workflows/.github/workflows/ctcClose.yml@main
+      secrets: inherit
+      with:
+        changeCaseId: ${{ needs.ctc-open.outputs.changeCaseId }}
+        status: Not Implemented

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -9,3 +9,22 @@ on:
 jobs:
   pr-validation:
     uses: salesforcecli/github-workflows/.github/workflows/validatePR.yml@main
+  code-quality:
+    strategy:
+      matrix:
+        node_version: [lts/-1]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.IDEE_GH_TOKEN }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+      - run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Prettier Check
+        run: npm run format:check

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "wireit",
     "compile": "wireit",
     "format": "wireit",
+    "format:check": "wireit",
     "lint": "wireit",
     "lint-fix": "npm eslint --fix",
     "test": "wireit",
@@ -70,6 +71,17 @@
     },
     "format": {
       "command": "prettier --write \"+(src|test|schemas)/**/*.+(ts|js|json)|command-snapshot.json\"",
+      "files": [
+        "src/**/*.ts",
+        "test/**/*.ts",
+        "schemas/**/*.json",
+        "command-snapshot.json",
+        ".prettier*"
+      ],
+      "output": []
+    },
+    "format:check": {
+      "command": "prettier --check \"+(src|test|schemas)/**/*.+(ts|js|json)|command-snapshot.json\"",
       "files": [
         "src/**/*.ts",
         "test/**/*.ts",


### PR DESCRIPTION
### What does this PR do?
- Add format: check wireit script
- update validate Pr to run lint/format check
- Pull in npmPublish GHA script for publishing with npm instead of yarn. 
### What issues does this PR fix or reference?

@W-16375705@

### Functionality Before

npm publish failed
could commit with lint/prettier errors

### Functionality After

merged blocked on lint/prettier
1st attempt at npm publish


