### PR TITLE
feat: use setting overrides for feature flags

### DIFF
--- a/scripts/setup-jest.ts
+++ b/scripts/setup-jest.ts
@@ -122,7 +122,9 @@ const getMockVSCode = () => {
           update: jest.fn()
         };
       },
-      onDidChangeConfiguration: jest.fn(),
+      onDidChangeConfiguration: () => ({
+        dispose: jest.fn()
+      }),
       onDidChangeTextDocument: jest.fn(),
       onDidOpenTextDocument: jest.fn(),
       createFileSystemWatcher: jest.fn().mockReturnValue({

--- a/src/api.ts
+++ b/src/api.ts
@@ -17,10 +17,19 @@ export enum ExperimentStatus {
   Expired = 'expired'
 }
 
+/**
+ * Definition of an experiment.
+ * @param name - The unique name of the experiment.
+ * @param type - The type of the experiment.
+ * @param distributionPercent - The percentage of users that should be included in the experiment.
+ * @param overrideSetting - The fully-qualified VSCode setting whose value overriddes the randomly assigned experiment value.
+ * @param expirationDate - The date at which the experiment should be considered expired.
+ */
 export interface ExperimentDefinition {
   name: string;
   type: ExperimentType;
   distributionPercent: number;
+  overrideSetting?: string;
   expirationDate?: string;
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -43,6 +43,7 @@ export interface IExperimentService {
   getExperiments(): Experiment[];
   getExperimentsState(): ExperimentState;
   getExperimentState(experiment: ExperimentDefinition): boolean;
+  dispose(): void;
 }
 
 export type ExperimentState = {

--- a/src/api.ts
+++ b/src/api.ts
@@ -43,7 +43,6 @@ export interface IExperimentService {
   getExperiments(): Experiment[];
   getExperimentsState(): ExperimentState;
   getExperimentState(experiment: ExperimentDefinition): boolean;
-  dispose(): void;
 }
 
 export type ExperimentState = {

--- a/src/experimentService.ts
+++ b/src/experimentService.ts
@@ -21,7 +21,7 @@ class ExperimentService implements IExperimentService {
     return ExperimentService.instance;
   }
 
-  stateManager: ExperimentStateManager | undefined;
+  private stateManager: ExperimentStateManager | undefined;
 
   private constructor() {}
 

--- a/src/experimentService.ts
+++ b/src/experimentService.ts
@@ -55,12 +55,6 @@ class ExperimentService implements IExperimentService {
     const result = this.stateManager.getExperimentState(experiment);
     return result;
   }
-
-  dispose(): void {
-    if (this.stateManager) {
-      this.stateManager.dispose();
-    }
-  }
 }
 
 export function getExperimentService(): IExperimentService {

--- a/src/experimentService.ts
+++ b/src/experimentService.ts
@@ -55,6 +55,12 @@ class ExperimentService implements IExperimentService {
     const result = this.stateManager.getExperimentState(experiment);
     return result;
   }
+
+  dispose(): void {
+    if (this.stateManager) {
+      this.stateManager.dispose();
+    }
+  }
 }
 
 export function getExperimentService(): IExperimentService {

--- a/src/internals/experimentState.ts
+++ b/src/internals/experimentState.ts
@@ -15,14 +15,12 @@ export class ExperimentStateManager {
   private context: vscode.ExtensionContext;
   private stateCache: ExperimentState;
   private experiments: Experiment[] = [];
+  private disposables: vscode.Disposable[] = [];
 
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
     this.stateCache = {};
-    this.experiments = [];
-    vscode.workspace.onDidChangeConfiguration(() => {
-      this.processOverrides();
-    });
+    this.disposables.push(vscode.workspace.onDidChangeConfiguration(this.handleConfigurationChange, this));
   }
 
   async assignExperiments(experiments: ExperimentDefinition[]): Promise<void> {
@@ -70,6 +68,14 @@ export class ExperimentStateManager {
   getExperiments(): Experiment[] {
     return this.experiments;
   }
+
+  dispose(): void {
+    this.disposables.forEach((disposable) => disposable.dispose());
+  }
+
+  private handleConfigurationChange(): void {
+      this.processOverrides();
+    }
 
   private processOverrides(): void {
     this.experiments.forEach((experiment) => {

--- a/src/internals/experimentState.ts
+++ b/src/internals/experimentState.ts
@@ -15,12 +15,11 @@ export class ExperimentStateManager {
   private context: vscode.ExtensionContext;
   private stateCache: ExperimentState;
   private experiments: Experiment[] = [];
-  private disposables: vscode.Disposable[] = [];
 
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
     this.stateCache = {};
-    this.disposables.push(vscode.workspace.onDidChangeConfiguration(this.handleConfigurationChange, this));
+    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(this.handleConfigurationChange, this));
   }
 
   async assignExperiments(experiments: ExperimentDefinition[]): Promise<void> {
@@ -69,13 +68,9 @@ export class ExperimentStateManager {
     return this.experiments;
   }
 
-  dispose(): void {
-    this.disposables.forEach((disposable) => disposable.dispose());
-  }
-
   private handleConfigurationChange(): void {
-      this.processOverrides();
-    }
+    this.processOverrides();
+  }
 
   private processOverrides(): void {
     this.experiments.forEach((experiment) => {

--- a/src/internals/experimentState.ts
+++ b/src/internals/experimentState.ts
@@ -20,7 +20,7 @@ export class ExperimentStateManager {
     this.context = context;
     this.stateCache = {};
     vscode.workspace.onDidChangeConfiguration(() => {
-      this.processOverrides(this.experiments);
+      this.processOverrides();
     });
   }
 
@@ -44,10 +44,9 @@ export class ExperimentStateManager {
         return { ...experiment, status, state };
       });
 
-    this.processOverrides(populatedExperiments);
-
     await this.context.globalState.update(EXPERIMENT_STATE_KEY, this.stateCache);
     this.experiments = populatedExperiments;
+    this.processOverrides();
   }
 
   getExperimentState(experiment: ExperimentDefinition): boolean {
@@ -71,9 +70,9 @@ export class ExperimentStateManager {
     return this.experiments;
   }
 
-  private processOverrides(experiments: Experiment[]): void {
-    if (experiments) {
-      experiments.forEach((experiment) => {
+  private processOverrides(): void {
+    if (this.experiments) {
+      this.experiments.forEach((experiment) => {
         if (experiment.overrideSetting && experiment.status === ExperimentStatus.Active) {
           const override = vscode.workspace.getConfiguration().get<boolean>(experiment.overrideSetting);
           if (override !== undefined) {

--- a/src/internals/experimentState.ts
+++ b/src/internals/experimentState.ts
@@ -19,6 +19,7 @@ export class ExperimentStateManager {
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
     this.stateCache = {};
+    this.experiments = [];
     vscode.workspace.onDidChangeConfiguration(() => {
       this.processOverrides();
     });
@@ -71,16 +72,14 @@ export class ExperimentStateManager {
   }
 
   private processOverrides(): void {
-    if (this.experiments) {
-      this.experiments.forEach((experiment) => {
-        if (experiment.overrideSetting && experiment.status === ExperimentStatus.Active) {
-          const override = vscode.workspace.getConfiguration().get<boolean>(experiment.overrideSetting);
-          if (override !== undefined) {
-            experiment.state = override;
-            this.stateCache[experiment.name] = override;
-          }
+    this.experiments.forEach((experiment) => {
+      if (experiment.overrideSetting && experiment.status === ExperimentStatus.Active) {
+        const override = vscode.workspace.getConfiguration().get<boolean>(experiment.overrideSetting);
+        if (override !== undefined) {
+          experiment.state = override;
+          this.stateCache[experiment.name] = override;
         }
-      });
-    }
+      }
+    });
   }
 }

--- a/test/unit/experimentService.test.ts
+++ b/test/unit/experimentService.test.ts
@@ -42,6 +42,7 @@ describe('ExperimentService', () => {
   let getExperimentsSpy: jest.SpyInstance;
   let getExperimentStateSpy: jest.SpyInstance;
   let getExperimentsStateSpy: jest.SpyInstance;
+  let disposeSpy: jest.SpyInstance;
 
   let experimentServiceInst: IExperimentService;
   beforeEach(() => {
@@ -51,6 +52,7 @@ describe('ExperimentService', () => {
     getExperimentsSpy = mockedExperimentState.prototype.getExperiments.mockReturnValue(fakeExperiments);
     getExperimentStateSpy = mockedExperimentState.prototype.getExperimentState;
     getExperimentsStateSpy = mockedExperimentState.prototype.getExperimentsState.mockReturnValue(fakeExperimentState);
+    disposeSpy = mockedExperimentState.prototype.dispose;
   });
 
   it('should register and return experiments', () => {
@@ -100,5 +102,11 @@ describe('ExperimentService', () => {
     }).toThrow(REGISTER_FIRST_ERROR);
 
     expect(getExperimentsStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('Should dispose of the state manager.', () => {
+    experimentServiceInst.dispose();
+
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/unit/experimentService.test.ts
+++ b/test/unit/experimentService.test.ts
@@ -42,7 +42,6 @@ describe('ExperimentService', () => {
   let getExperimentsSpy: jest.SpyInstance;
   let getExperimentStateSpy: jest.SpyInstance;
   let getExperimentsStateSpy: jest.SpyInstance;
-  let disposeSpy: jest.SpyInstance;
 
   let experimentServiceInst: IExperimentService;
   beforeEach(() => {
@@ -52,7 +51,6 @@ describe('ExperimentService', () => {
     getExperimentsSpy = mockedExperimentState.prototype.getExperiments.mockReturnValue(fakeExperiments);
     getExperimentStateSpy = mockedExperimentState.prototype.getExperimentState;
     getExperimentsStateSpy = mockedExperimentState.prototype.getExperimentsState.mockReturnValue(fakeExperimentState);
-    disposeSpy = mockedExperimentState.prototype.dispose;
   });
 
   it('should register and return experiments', () => {
@@ -102,11 +100,5 @@ describe('ExperimentService', () => {
     }).toThrow(REGISTER_FIRST_ERROR);
 
     expect(getExperimentsStateSpy).not.toHaveBeenCalled();
-  });
-
-  it('Should dispose of the state manager.', () => {
-    experimentServiceInst.dispose();
-
-    expect(disposeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/unit/internals/experimentState.test.ts
+++ b/test/unit/internals/experimentState.test.ts
@@ -14,6 +14,9 @@ const context = {
   globalState: {
     get: jest.fn(),
     update: jest.fn()
+  },
+  subscriptions: {
+    push: jest.fn()
   }
 };
 
@@ -197,15 +200,6 @@ describe('ExperimentStateManager', () => {
     const result = experimentStateManager.getExperiments();
 
     expect(result).toEqual([]);
-  });
-
-  it('Should dispose of all disposables.', () => {
-    const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
-    const disposables = (experimentStateManager as any).disposables;
-    experimentStateManager.dispose();
-
-    expect(disposables.length).toBe(1);
-    expect(disposables[0].dispose).toHaveBeenCalled();
   });
 
   it('Should handle configuration change.', () => {

--- a/test/unit/internals/experimentState.test.ts
+++ b/test/unit/internals/experimentState.test.ts
@@ -199,6 +199,23 @@ describe('ExperimentStateManager', () => {
     expect(result).toEqual([]);
   });
 
+  it('Should dispose of all disposables.', () => {
+    const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
+    const disposables = (experimentStateManager as any).disposables;
+    experimentStateManager.dispose();
+
+    expect(disposables.length).toBe(1);
+    expect(disposables[0].dispose).toHaveBeenCalled();
+  });
+
+  it('Should handle configuration change.', () => {
+    const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
+    (experimentStateManager as any).processOverrides = jest.fn();
+    (experimentStateManager as any).handleConfigurationChange();
+
+    expect((experimentStateManager as any).processOverrides).toHaveBeenCalled();
+  });
+
   it('Should use override setting value if present.', () => {
     jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
       get: jest.fn().mockReturnValue(true)

--- a/test/unit/internals/experimentState.test.ts
+++ b/test/unit/internals/experimentState.test.ts
@@ -91,7 +91,7 @@ describe('ExperimentStateManager', () => {
     });
   });
 
-  it('should process overrides when assigning experiments', () => {
+  it('should process overrides when assigning experiments', async () => {
     context.globalState.get.mockReturnValue({});
     jest.spyOn(Utils, 'randomAssignment').mockReturnValue(true);
     jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
@@ -107,7 +107,7 @@ describe('ExperimentStateManager', () => {
       }
     ];
     const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
-    experimentStateManager.assignExperiments(experiments);
+    await experimentStateManager.assignExperiments(experiments);
     const result = experimentStateManager.getExperimentState(experiments[0]);
 
     expect(vscode.workspace.getConfiguration).toHaveBeenCalled();
@@ -215,8 +215,9 @@ describe('ExperimentStateManager', () => {
       }
     ];
     const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
+    (experimentStateManager as any).experiments = experiments;
     (experimentStateManager as any).stateCache = { Experiment1: false };
-    (experimentStateManager as any).processOverrides(experiments);
+    (experimentStateManager as any).processOverrides();
     const result = experimentStateManager.getExperimentState(experiments[0]);
 
     expect(vscode.workspace.getConfiguration).toHaveBeenCalled();
@@ -239,8 +240,9 @@ describe('ExperimentStateManager', () => {
       }
     ];
     const experimentStateManager = new ExperimentStateManager(context as any as vscode.ExtensionContext);
+    (experimentStateManager as any).experiments = experiments;
     (experimentStateManager as any).stateCache = { Experiment1: false };
-    (experimentStateManager as any).processOverrides(experiments);
+    (experimentStateManager as any).processOverrides();
     const result = experimentStateManager.getExperimentState(experiments[0]);
 
     expect(vscode.workspace.getConfiguration).not.toHaveBeenCalled();


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?

This PR introduces the `overrideSetting` field to the experiment definition API. This field is used to specify a VSCode config setting whose value overrides the random experiment value for non-expired experiments.

### What issues does this PR fix or reference?

@W-16328968@

